### PR TITLE
Rename blob types

### DIFF
--- a/src/blob_api.jl
+++ b/src/blob_api.jl
@@ -40,4 +40,4 @@ Return the image of the `blob`.
 """
 intensity_map(blob::AbstractBlob) = blob.intensity_map
 
-location_raw(blob::BlobRefined) = blob.location_raw
+location_raw(blob::Blob) = blob.location_raw

--- a/src/blob_detection.jl
+++ b/src/blob_detection.jl
@@ -45,7 +45,7 @@ function detect_blobs(img::AbstractArray{T,N}, σscales;
     maxima = findlocalmaxima(img_LoG; edges)
     if !iszero(rthresh)
         imgmax = maximum(abs, img)
-        [refine(Blob(
+        [refine(BlobRaw(
             CartesianIndex(Base.tail(x.I)),
             sigmas[x[1]].*σshape,
             img_LoG[x],
@@ -53,7 +53,7 @@ function detect_blobs(img::AbstractArray{T,N}, σscales;
             )) for x in maxima if img_LoG[x] > rthresh*imgmax
         ]
     else
-        [refine(Blob(
+        [refine(BlobRaw(
             CartesianIndex(Base.tail(x.I)),
             sigmas[x[1]].*σshape,
             img_LoG[x],

--- a/src/blobs.jl
+++ b/src/blobs.jl
@@ -1,4 +1,4 @@
-export AbstractBlob, Blob, BlobRefined, DummyBlob
+export AbstractBlob, Blob, DummyBlob
 
 """
     AbstractBlob{T,S,N}
@@ -18,7 +18,7 @@ end
 
 
 """
-    struct Blob{T,S,N} <: AbstractBlob{T,S,N}
+    struct BlobRaw{T,S,N} <: AbstractBlob{T,S,N}
         location::CartesianIndex{N}
         σ::S
         amplitude::T
@@ -27,7 +27,7 @@ end
         intensity_map
     end
 """
-struct Blob{T,S,N} <: AbstractBlob{T,S,N}
+struct BlobRaw{T,S,N} <: AbstractBlob{T,S,N}
     location::CartesianIndex{N}
     σ::S
     amplitude::T
@@ -36,15 +36,25 @@ struct Blob{T,S,N} <: AbstractBlob{T,S,N}
     intensity_map
 end
 
-function Blob(
+function BlobRaw(
     location::CartesianIndex{N}, σ::S, amplitude::T, img::AbstractArray{T,N}
 ) where {T,S,N}
     img_pad, m0, m2 = image_moments(location, σ, img)
-    Blob(location, σ, amplitude, m0, m2, img_pad)
+    BlobRaw(location, σ, amplitude, m0, m2, img_pad)
 end
 
-
-struct BlobRefined{T,S,N} <: AbstractBlob{T,S,N}
+"""
+    struct Blob{T,S,N} <: AbstractBlob{T,S,N}
+        location::NTuple{N,Float64}
+        location_raw::CartesianIndex{N}
+        σ::S
+        amplitude::T
+        m0::T
+        m2::T
+        intensity_map
+    end
+"""
+struct Blob{T,S,N} <: AbstractBlob{T,S,N}
     location::NTuple{N,Float64}
     location_raw::CartesianIndex{N}
     σ::S
@@ -54,15 +64,15 @@ struct BlobRefined{T,S,N} <: AbstractBlob{T,S,N}
     intensity_map
 end
 
-function BlobRefined(blob::AbstractBlob{T,S,N}, offsets::NTuple{N,Float64}) where {T,S,N}
+function Blob(blob::AbstractBlob{T,S,N}, offsets::NTuple{N,Float64}) where {T,S,N}
     raw_location = location(blob)
-    BlobRefined(Tuple(raw_location) .+ offsets, raw_location, scale(blob),
+    Blob(Tuple(raw_location) .+ offsets, raw_location, scale(blob),
         amplitude(blob), zeroth_moment(blob), second_moment(blob), intensity_map(blob)
     )
 end
 
 
-function DummyBlob(BlobType::Type{BlobRefined{T,S,N}}) where {T,S,N}
+function DummyBlob(BlobType::Type{Blob{T,S,N}}) where {T,S,N}
     BlobType(
         ntuple(_ -> T(NaN), N),
         CartesianIndex(ntuple(_ -> 0, N)),

--- a/src/gui_blobs.jl
+++ b/src/gui_blobs.jl
@@ -1,0 +1,67 @@
+## GUI
+fig = Figure(; resolution=(1200,900), fontsize=28)
+
+# CONTROLS
+slider_frame = Slider(fig[4,1:4], range=eachindex(proc), startvalue=1)
+slider_size = Slider(fig[5,1:4], range=1:20, startvalue=1)
+slider_thresh = Slider(fig[6,1:4], range=0.01:0.01:0.4, startvalue=0.03)
+
+label_frame = Label(fig[4,5];
+    text=@lift("Frame: "*string($(slider_frame.value))),
+    halign=:left
+)
+label_size = Label(fig[5,5];
+    text=@lift("Blob size: "*string($(slider_size.value))),
+    halign=:left
+)
+label_thresh = Label(fig[6,5];
+    text=@lift("Threshold: "*string($(slider_thresh.value))),
+    halign=:left
+)
+
+# MAIN IMAGE WITH BLOBS
+ax1 = Axis(fig[1:3,1:3];
+    aspect=1, title="Blob detection preview",
+    xticksvisible = false, yticksvisible=false,
+    xticklabelsvisible = false, yticklabelsvisible = false,
+)
+img = @lift(Gray.(proc[$(slider_frame.value)]))
+blobs = @lift(detect_blobs(
+    proc[$(slider_frame.value)],
+    [$(slider_size.value)];
+    rthresh = $(slider_thresh.value)
+))
+
+heatmap!(ax1, img)
+scatter!(ax1, blobs; markersize=32, alpha=0.2, color=:red)
+
+# SECONDARY PLOTS WITH BLOB STATISTICS
+ax2 = Axis(fig[1, 4:5]; title="Blob amplitudes",
+    xlabel = "id", ylabel = "amplitude"
+)
+amp = @lift(amplitude.($blobs))
+amprange = @lift(extrema($amp))
+on(amp) do A
+    ampmin, ampmax = extrema(A)
+    n = length(A)
+    xlims!(ax2, 0.5, n+0.5)
+    ylims!(ax2, 0.0, 1.15*ampmax)
+end
+hlines!(ax2, slider_thresh.value)
+scatter!(ax2, amp)
+
+ax3 = Axis(fig[2:3, 4:5]; title="Intensity moments",
+    xlabel = rich("m", subscript("0")), ylabel = rich("m", subscript("2"))
+)
+getmoments(blob) = Point2f(zeroth_moment(blob), second_moment(blob))
+m = @lift(getmoments.($blobs))
+on(m) do M
+    x1,x2 = extrema(first.(M))
+    y1,y2 = extrema(last.(M))
+    xlims!(ax3, x1*0.75, x2*1.25)
+    ylims!(ax3, y1*0.75, y2*1.25)
+end
+scatter!(ax3, m)
+
+
+fig

--- a/src/gui_tracks.jl
+++ b/src/gui_tracks.jl
@@ -1,0 +1,74 @@
+## GUI
+fig = Figure(; resolution=(1200,900), fontsize=28)
+stack = proc[1:200]
+allblobs = detect_blobs(stack, 2:4; rthresh=0.05)
+
+# CONTROLS
+slider_frame = Slider(fig[4,1:4], range=eachindex(stack), startvalue=1)
+slider_memory = Slider(fig[5,1:4], range=1:10, startvalue=1)
+slider_maxdist = Slider(fig[6,1:4], range=5:5:75, startvalue=30)
+
+label_frame = Label(fig[4,5];
+    text=@lift("Frame: "*string($(slider_frame.value))),
+    halign=:left
+)
+label_memory = Label(fig[5,5];
+    text=@lift("Memory: "*string($(slider_memory.value))),
+    halign=:left
+)
+label_maxdist = Label(fig[6,5];
+    text=@lift("Max distance: "*string($(slider_maxdist.value))),
+    halign=:left
+)
+
+# MAIN IMAGE WITH BLOBS AND TRACKS
+ax1 = Axis(fig[1:3,1:3];
+    aspect=1, title="Blob detection preview",
+    xticksvisible = false, yticksvisible=false,
+    xticklabelsvisible = false, yticklabelsvisible = false,
+)
+img = @lift(Gray.(stack[$(slider_frame.value)]))
+blobs = @lift(allblobs[$(slider_frame.value)])
+tracks = @lift(blobtracking(allblobs;
+    memory=$(slider_memory.value),
+    maxdist=$(slider_maxdist.value),
+    minlife=5
+))
+
+heatmap!(ax1, img)
+scatter!(ax1, blobs; markersize=32, alpha=0.2, color=:red)
+on(tracks) do _tracks
+    for s in _tracks
+        lines!(ax1, s, slider_frame.value, 50; linewidth=2)
+    end
+end
+
+# SECONDARY PLOTS WITH BLOB STATISTICS
+ax2 = Axis(fig[1, 4:5]; title="Blob amplitudes",
+    xlabel = "id", ylabel = "amplitude"
+)
+amp = @lift(amplitude.($blobs))
+amprange = @lift(extrema($amp))
+on(amp) do A
+    ampmin, ampmax = extrema(A)
+    n = length(A)
+    xlims!(ax2, 0.5, n+0.5)
+    ylims!(ax2, 0.0, 1.15*ampmax)
+end
+scatter!(ax2, amp)
+
+ax3 = Axis(fig[2:3, 4:5]; title="Intensity moments",
+    xlabel = rich("m", subscript("0")), ylabel = rich("m", subscript("2"))
+)
+getmoments(blob) = Point2f(zeroth_moment(blob), second_moment(blob))
+m = @lift(getmoments.($blobs))
+on(m) do M
+    x1,x2 = extrema(first.(M))
+    y1,y2 = extrema(last.(M))
+    xlims!(ax3, x1*0.75, x2*1.25)
+    ylims!(ax3, y1*0.75, y2*1.25)
+end
+scatter!(ax3, m)
+
+
+fig

--- a/src/linking_cost.jl
+++ b/src/linking_cost.jl
@@ -40,11 +40,11 @@ function evaluate_maxcost(::Type{<:AbstractBlob{T,S,N}},
     # define two dummy blobs dt*maxdist apart and evaluate their linking cost
     posA = ntuple(_ -> 0.0, N)
     posB = ntuple(i -> i==1 ? Float64(dt*maxdist) : 0.0, N)
-    A = BlobRefined(
+    A = Blob(
         posA, CartesianIndex(ntuple(zero, N)),
         S(0 for _ in 1:N), zero(T), zero(T), zero(T), []
     )
-    B = BlobRefined(
+    B = Blob(
         posB, CartesianIndex(ntuple(zero, N)),
         S(0 for _ in 1:N),
         zero(T), zero(T), zero(T), []

--- a/src/location_refinement.jl
+++ b/src/location_refinement.jl
@@ -6,11 +6,11 @@ Estimate the real location of `blob` through subpixel localization.
 """
 function refine(blob::AbstractBlob)
     ε = offsets(blob)
-    return BlobRefined(blob, ε)
+    return Blob(blob, ε)
 end
-refine(blob::BlobRefined) = blob # do nothing if position is already refined
+refine(blob::Blob) = blob # do nothing if position is already refined
 
-function offsets(blob::Blob{T,S,2}) where {T,S}
+function offsets(blob::BlobRaw{T,S,2}) where {T,S}
     x, y = location(blob).I
     σx, σy = scale(blob)
     m0 = zeroth_moment(blob)
@@ -39,4 +39,4 @@ function offsets(blob::Blob{T,S,2}) where {T,S}
     ==#
     return (εx, εy)
 end
-offsets(blob::BlobRefined{T,S,N}) where {T,S,N} = ntuple(_ -> 0.0, N)
+offsets(blob::Blob{T,S,N}) where {T,S,N} = ntuple(_ -> 0.0, N)


### PR DESCRIPTION
Closes #8 
- Renames `Blob`->`BlobRaw`, `BlobRefined`->`Blob`
- makes `BlobRaw` private