### PR TITLE
generalize detection to any dimensionality

### DIFF
--- a/src/image_moments.jl
+++ b/src/image_moments.jl
@@ -4,27 +4,24 @@ Evaluate the zeroth and second intensity moment of a blob in `img`
 identified as a a region of size `σ` around `location`.
 Returns a tuple with a view of the blob and the two moments.
 """
-function image_moments(location::CartesianIndex{2}, σ, img::AbstractArray{T,2}) where T
-    x, y = location.I
-    σx, σy = σ
-    σx2 = σx^2
-    σy2 = σy^2
+function image_moments(location::CartesianIndex{N}, σ, img::AbstractArray{T,N}) where {T,N}
+    x = location.I
+    σ2 = σ.^2
     m0 = zero(float(T))
     m2 = zero(float(T))
-    img_padded = PaddedView(0.0, img, (x-σx:x+σx, y-σy:y+σy))
+    # define rectangle around the blob
+    view_range = ntuple(i -> (x[i]-σ[i]):(x[i]+σ[i]), N)
+    img_padded = PaddedView(0.0, img, view_range)
     I = zero(img_padded)
-    for j in -σy:σy, i in -σx:σx
-        i2 = i^2
-        j2 = j^2
-        if i2/σx2 + j2/σy2 <= 1
-            A = img_padded[x+i, y+j]
-            I[x+i, y+j] = A
+    for c in CartesianIndices(img_padded)
+        delta2 = (c.I .- x).^2
+        if sum(delta2./σ2) <= 1 # N-sphere of radius σ
+            A = img_padded[c]
+            I[c] = A
             m0 += A
-            m2 += (i2 + j2) * A
+            m2 += sum(delta2)*A
         end
     end
-    #m2 /= (m0 * σx * σy)
-    #m0 /= (σx * σy)
     m2 /= m0
     return I, m0, m2
 end

--- a/src/location_refinement.jl
+++ b/src/location_refinement.jl
@@ -1,5 +1,3 @@
-export refine, offsets
-
 """
     refine(blob::AbstractBlob)
 Estimate the real location of `blob` through subpixel localization.

--- a/src/location_refinement.jl
+++ b/src/location_refinement.jl
@@ -16,22 +16,18 @@ function offsets(blob::BlobRaw{T,S,N}) where {T,S,N}
     x = location(blob).I
     ε = zeros(N)
     for c in CartesianIndices(I)
-        delta = x .- c.I
+        delta = c.I .- x
         ε .+= delta .* I[CartesianIndex(x .+ delta)]
     end
     ε ./= m0
-    # BUG: was bugged with previous 2D implementation; should work now but needs check.
-    # When new_location is set it does not coincide with the center of intensity map;
-    # on the following iteration indexing is messed up and goes out of bounds
-    #==
     if any(abs(d) > 0.5 for d in ε)
-        new_location = CartesianIndex(@. x + Int(sign(ε)))
+        # reassign the dimensions for which ε>1/2
+        new_location = CartesianIndex(Tuple(@. x + round(Int, ε)))
         new_blob = BlobRaw(new_location, scale(blob), amplitude(blob),
             zeroth_moment(blob), second_moment(blob), intensity_map(blob)
         )
         offsets(new_blob)
     end
-    ==#
     return Tuple(ε)
 end
 offsets(blob::Blob{T,S,N}) where {T,S,N} = ntuple(_ -> 0.0, N)


### PR DESCRIPTION
Reimplements `image_moments` and `offsets` to work for general dimensions.
Also fixes the bug with re-iteration in the subpixel localization

Closes #18 